### PR TITLE
use the cluster to find if the keyspace exists

### DIFF
--- a/lib/cequel/metal/keyspace.rb
+++ b/lib/cequel/metal/keyspace.rb
@@ -247,15 +247,7 @@ module Cequel
 
       # @return [Boolean] true if the keyspace exists
       def exists?
-        statement = <<-CQL
-          SELECT keyspace_name
-          FROM system.schema_keyspaces
-          WHERE keyspace_name = ?
-        CQL
-
-        log('CQL', statement, [name]) do
-          client_without_keyspace.execute(sanitize(statement, [name])).any?
-        end
+        cluster.has_keyspace?(name)
       end
 
       private


### PR DESCRIPTION
This will delegate the call to the driver to determine if the keyspace exists in the cluster
